### PR TITLE
Typo: "past" should be "paste"

### DIFF
--- a/docs/docs/creating-a-new-test-project.md
+++ b/docs/docs/creating-a-new-test-project.md
@@ -71,6 +71,6 @@ A neat trick, which will limit the `import` statements needed in your test proje
 </PropertyGroup>
 ```
 
-### Make copy/past of HTML easier
+### Make copy/paste of HTML easier
 
 When writing C# based tests, you sometime want to copy/paste some HTML into C# strings from e.g. a Razor file. This is tedious to do manually as you have to escape the quotes and other special characters. The extension, [SmartPaster2019](https://marketplace.visualstudio.com/items?itemName=martinw.SmartPaster2013), allows us to copy strings where any character that needs to be escaped will be automatically.


### PR DESCRIPTION
Typo: "past" should be "paste"