### PR TITLE
AddTestAuthorization adds CascadingAuthenticationState to render tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ List of changes in existing functionality.
 
 - Marked MarkupMatches methods as assertion methods to stop SonarSource analyzers complaining about missing assertions in tests. By [@egil](https://github.com/egil) in [#229](https://github.com/egil/bUnit/pull/229).
 
+- `AddTestAuthorization` now extends `TestContext` instead of `TestServiceProvider`, and also automatically adds the `CascadingAuthenticationState` component to the root render tree. [@egil](https://github.com/egil) in [#237](https://github.com/egil/bUnit/pull/367).
+
 ### Deprecated
 List of soon-to-be removed features.
 

--- a/docs/samples/components/UserInfo.razor
+++ b/docs/samples/components/UserInfo.razor
@@ -9,20 +9,17 @@
 {
   <h1>Please log in!</h1>
 }
-<CascadingAuthenticationState>
-  <AuthorizeView>
-    <Authorized>
-      <p>State: Authorized</p>
-    </Authorized>
-    <Authorizing>
-      <p>State: Authorizing</p>
-    </Authorizing>
-    <NotAuthorized>
-      <p>State: Not authorized</p>
-    </NotAuthorized>
-  </AuthorizeView>
-</CascadingAuthenticationState>
-
+<AuthorizeView>
+  <Authorized>
+    <p>State: Authorized</p>
+  </Authorized>
+  <Authorizing>
+    <p>State: Authorizing</p>
+  </Authorizing>
+  <NotAuthorized>
+    <p>State: Not authorized</p>
+  </NotAuthorized>
+</AuthorizeView>
 @code
 {
   bool isAuthenticated = false;

--- a/docs/samples/components/UserRights.razor
+++ b/docs/samples/components/UserRights.razor
@@ -2,28 +2,26 @@
 @using System.Security.Claims
 @using System.Globalization
 
-<CascadingAuthenticationState>
+<AuthorizeView>
+  <h1>Hi @context.User.Identity.Name, you have these claims and rights:</h1>
+</AuthorizeView>
+<ul>
   <AuthorizeView>
-    <h1>Hi @context.User.Identity.Name, you have these claims and rights:</h1>
+    @foreach (var claim in @context.User.FindAll(x => x.Type != ClaimTypes.Name))
+    {
+      <li>@GetClaimName(claim): @claim.Value</li>
+    }
   </AuthorizeView>
-  <ul>
-    <AuthorizeView>
-      @foreach (var claim in @context.User.FindAll(x => x.Type != ClaimTypes.Name))
-      {
-        <li>@GetClaimName(claim): @claim.Value</li>
-      }
-    </AuthorizeView>
-    <AuthorizeView Roles="superuser">
-      <li>You have the role SUPER USER</li>
-    </AuthorizeView>  
-    <AuthorizeView Roles="admin">
-      <li>You have the role ADMIN</li>
-    </AuthorizeView>
-    <AuthorizeView Policy="content-editor">
-      <li>You are a CONTENT EDITOR</li>
-    </AuthorizeView>
-  </ul>
-</CascadingAuthenticationState>
+  <AuthorizeView Roles="superuser">
+    <li>You have the role SUPER USER</li>
+  </AuthorizeView>  
+  <AuthorizeView Roles="admin">
+    <li>You have the role ADMIN</li>
+  </AuthorizeView>
+  <AuthorizeView Policy="content-editor">
+    <li>You are a CONTENT EDITOR</li>
+  </AuthorizeView>
+</ul>
 
 @code 
 {

--- a/docs/samples/tests/xunit/InjectAuthServiceTest.cs
+++ b/docs/samples/tests/xunit/InjectAuthServiceTest.cs
@@ -11,7 +11,7 @@ namespace Bunit.Docs.Samples
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUserName", AuthorizationState.Authorized);
 
 			// act
@@ -26,7 +26,7 @@ namespace Bunit.Docs.Samples
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 
 			// act
 			var cut = ctx.RenderComponent<InjectAuthService>();

--- a/docs/samples/tests/xunit/UserInfoTest.cs
+++ b/docs/samples/tests/xunit/UserInfoTest.cs
@@ -10,7 +10,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      ctx.Services.AddTestAuthorization();
+      ctx.AddTestAuthorization();
 
       // Act
       var cut = ctx.RenderComponent<UserInfo>();
@@ -25,7 +25,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorizing();
 
       // Act
@@ -41,7 +41,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER", AuthorizationState.Unauthorized);
 
       // Act
@@ -57,7 +57,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
 
       // Act

--- a/docs/samples/tests/xunit/UserRightsTest.cs
+++ b/docs/samples/tests/xunit/UserRightsTest.cs
@@ -12,7 +12,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
 
       // Act
@@ -28,7 +28,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetRoles("superuser");
 
@@ -47,7 +47,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetRoles("admin", "superuser");
 
@@ -67,7 +67,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetPolicies("content-editor");
 
@@ -86,7 +86,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetPolicies("content-editor", "approver");
 
@@ -105,7 +105,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetClaims(        
         new Claim(ClaimTypes.Email, "test@example.com"),
@@ -128,7 +128,7 @@ namespace Bunit.Docs.Samples
     {
       // Arrange
       using var ctx = new TestContext();
-      var authContext = ctx.Services.AddTestAuthorization();
+      var authContext = ctx.AddTestAuthorization();
       authContext.SetAuthorized("TEST USER");
       authContext.SetRoles("admin", "superuser");
       authContext.SetPolicies("content-editor");

--- a/docs/site/docs/test-doubles/faking-auth.md
+++ b/docs/site/docs/test-doubles/faking-auth.md
@@ -15,7 +15,10 @@ The test implementation of Blazor's authentication and authorization can be put 
 - **Authenticated** and **authorized** 
 - **Authenticated** and **authorized** with one or more **roles**, **claims**, and/or **policies**
 
-bUnit's authentication and authorization implementation is easily available by calling [`AddTestAuthorization()`](xref:Bunit.TestDoubles.FakeAuthorizationExtensions.AddTestAuthorization(Bunit.TestServiceProvider)) on a test context's `Services` collection. This returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
+bUnit's authentication and authorization implementation is easily available by calling [`AddTestAuthorization()`](xref:Bunit.TestDoubles.FakeAuthorizationExtensions.AddTestAuthorization(Bunit.TestContext)) on a test context. This adds the necessary services to the `Services` collection and the `CascadingAuthenticationState` component to the [root render tree](xref:root-render-tree). The method returns an instance of the <xref:Bunit.TestDoubles.TestAuthorizationContext> type that allows you to control the authentication and authorization state for a test.
+
+> [!NOTE]
+> If your inherits directly from bUnit's <xref:Bunit.TestContext> as described in <xref:writing-csharp-tests#remove-boilerplate-code-from-tests>, then you need to call the [`AddTestAuthorization()`](xref:Bunit.TestDoubles.FakeAuthorizationExtensions.AddTestAuthorization(Bunit.TestContext)) method like so: `this.AddTestAuthorization()`.
 
 The following sections will show how to set each of these states in a test.
 

--- a/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationExtensions.cs
+++ b/src/bunit.web/TestDoubles/Authorization/FakeAuthorizationExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components.Authorization;
+
 namespace Bunit.TestDoubles
 {
 	/// <summary>
@@ -7,14 +9,17 @@ namespace Bunit.TestDoubles
 	public static class FakeAuthorizationExtensions
 	{
 		/// <summary>
-		/// Adds the appropriate auth services to the <see cref="TestServiceProvider"/> to enable
-		/// an authenticated user.
+		/// Adds the appropriate Blazor authentication and authorization services to the <see cref="TestServiceProvider"/> to enable
+		/// an authenticated user, as well as adding the <see cref="CascadingAuthenticationState"/> component to the
+		/// <see cref="TestContext.RenderTree"/>.
 		/// </summary>
-		public static TestAuthorizationContext AddTestAuthorization(this TestServiceProvider serviceProvider)
+		public static TestAuthorizationContext AddTestAuthorization(this TestContext context)
 		{
+			context.RenderTree.TryAdd<CascadingAuthenticationState>();
+
 			var authCtx = new TestAuthorizationContext();
 			authCtx.SetNotAuthorized();
-			authCtx.RegisterAuthorizationServices(serviceProvider);
+			authCtx.RegisterAuthorizationServices(context.Services);
 			return authCtx;
 		}
 	}

--- a/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithClaims.razor
+++ b/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithClaims.razor
@@ -2,20 +2,18 @@
 @using System.Security.Claims
 @inject AuthenticationStateProvider AuthenticationStateProvider
 
-<CascadingAuthenticationState>
-	<AuthorizeView>
-		<div>Authorized!</div>
-		<div>Name: @userName</div>
-		@if (hasUserEmail)
-		{
-			<div>Email: @userEmail</div>
-		}
-		@if (hasUserId)
-		{
-			<div>Id: @userId</div>
-		}
-	</AuthorizeView>
-</CascadingAuthenticationState>
+<AuthorizeView>
+	<div>Authorized!</div>
+	<div>Name: @userName</div>
+	@if (hasUserEmail)
+	{
+		<div>Email: @userEmail</div>
+	}
+	@if (hasUserId)
+	{
+		<div>Id: @userId</div>
+	}
+</AuthorizeView>
 
 @code {
 	string userName = "";

--- a/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithPolicy.razor
+++ b/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithPolicy.razor
@@ -1,7 +1,5 @@
 @using Microsoft.AspNetCore.Components.Authorization
 
-<CascadingAuthenticationState>
-	<AuthorizeView Policy="ContentViewer">
-		Authorized for content viewers.
-	</AuthorizeView>
-</CascadingAuthenticationState>
+<AuthorizeView Policy="ContentViewer">
+	Authorized for content viewers.
+</AuthorizeView>

--- a/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithRole.razor
+++ b/tests/bunit.testassets/SampleComponents/SimpleAuthViewWithRole.razor
@@ -1,7 +1,5 @@
 @using Microsoft.AspNetCore.Components.Authorization
 
-<CascadingAuthenticationState>
-	<AuthorizeView Roles="Admin">
-		Authorized content for admins.
-	</AuthorizeView>
-</CascadingAuthenticationState>
+<AuthorizeView Roles="Admin">
+	Authorized content for admins.
+</AuthorizeView>

--- a/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/AuthorizationTest.cs
@@ -12,7 +12,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// Arrange
 			using var ctx = new TestContext();
-			ctx.Services.AddTestAuthorization();
+			ctx.AddTestAuthorization();
 
 			// Act
 			var cut = ctx.RenderComponent<SimpleAuthView>();
@@ -26,7 +26,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser", AuthorizationState.Authorized);
 
 			// act
@@ -41,7 +41,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser", AuthorizationState.Unauthorized);
 
 			// act
@@ -56,7 +56,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 
 			// start off unauthenticated.
 			var cut = ctx.RenderComponent<SimpleAuthView>();
@@ -76,7 +76,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser005", AuthorizationState.Authorized);
 
 			// start off unauthenticated.
@@ -111,7 +111,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser").SetPolicies("ContentViewer");
 
 			// act
@@ -126,7 +126,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser");
 			// act
 			var cut = ctx.RenderComponent<SimpleAuthViewWithPolicy>();
@@ -140,7 +140,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser").SetPolicies("OtherPolicy");
 
 			// act
@@ -155,7 +155,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser").SetRoles("Admin");
 
 			// act
@@ -170,7 +170,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser");
 
 			// act
@@ -185,7 +185,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser").SetRoles("NotAdmin");
 
 			// act
@@ -200,7 +200,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorizing();
 
 			// act
@@ -216,7 +216,7 @@ namespace Bunit.TestDoubles.Authorization
 			// arrange
 			var userId = new Guid("{5d5fa9c1-abf9-4ed6-8fb0-3365382b629c}");
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			var emailClaim = new Claim(ClaimTypes.Email, "user@test.com");
 			var uuidClaim = new Claim(ClaimTypes.Sid, userId.ToString());
 			authContext.SetAuthorized("TestUser").SetClaims(uuidClaim, emailClaim);
@@ -237,7 +237,7 @@ namespace Bunit.TestDoubles.Authorization
 		{
 			// arrange
 			using var ctx = new TestContext();
-			var authContext = ctx.Services.AddTestAuthorization();
+			var authContext = ctx.AddTestAuthorization();
 			authContext.SetAuthorized("TestUser");
 
 			// act

--- a/tests/bunit.web.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
+++ b/tests/bunit.web.tests/TestDoubles/Authorization/TestAuthorizationContextTest.cs
@@ -2,16 +2,13 @@ using Xunit;
 
 namespace Bunit.TestDoubles.Authorization
 {
-	public class TestAuthorizationContextTest
+	public class TestAuthorizationContextTest : TestContext
 	{
 		[Fact(DisplayName = "Register Authorization services with unauthenticated user.")]
 		public void Test003()
 		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 
 			// assert
 			Assert.False(authContext.IsAuthenticated);
@@ -23,11 +20,8 @@ namespace Bunit.TestDoubles.Authorization
 		[Fact(DisplayName = "Register Authorization services with authorizing state.")]
 		public void Test0031()
 		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 			authContext.SetAuthorizing();
 
 			// assert
@@ -40,11 +34,8 @@ namespace Bunit.TestDoubles.Authorization
 		[Fact(DisplayName = "Register Authorization services with authenticated but unauthorized user.")]
 		public void Test002()
 		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 			authContext.SetAuthorized("DarthPedro", AuthorizationState.Unauthorized);
 
 			// assert
@@ -57,11 +48,8 @@ namespace Bunit.TestDoubles.Authorization
 		[Fact(DisplayName = "Register Authorization services with authenticated and authorized user")]
 		public void Test0010()
 		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 			authContext.SetAuthorized("DarthPedro");
 
 			// assert
@@ -74,11 +62,8 @@ namespace Bunit.TestDoubles.Authorization
 		[Fact(DisplayName = "Register Authorization services with authenticated and authorized user and role.")]
 		public void Test001()
 		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 			authContext.SetAuthorized("DarthPedro");
 			authContext.SetRoles("some-role");
 
@@ -91,12 +76,9 @@ namespace Bunit.TestDoubles.Authorization
 
 		[Fact(DisplayName = "Register Authorization services with authenticated and authorized user and policy.")]
 		public void Test0011()
-		{
-			// arrange
-			using var sp = new TestServiceProvider();
-
+		{			
 			// act
-			var authContext = sp.AddTestAuthorization();
+			var authContext = this.AddTestAuthorization();
 			authContext.SetAuthorized("DarthPedro");
 			authContext.SetPolicies("TestPolicy", "Other");
 


### PR DESCRIPTION
`AddTestAuthorization` now extends `TestContext` instead of `TestServiceProvider`, and also automatically adds the `CascadingAuthenticationState` component to the root render tree

Closes #171.

## Pull request description
<!--- 
    Describe the changes and motivation behind them here, if it is not obvious
    from the related issues. Does it have new features, breaking changes, etc. 
-->

### PR meta checklist
- [x] Pull request is targeting at `DEV` branch.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Content checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
