### PR TITLE
TestContext.Render(renderFragment) and MarkupMatches(renderFragment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,58 @@ List of new features.
 
   By [@egil](https://github.com/egil) in [#260](https://github.com/egil/bUnit/pull/260).
 
+- Added `Render(RenderFragment)` and `Render<TComponent>(RenderFragment)` methods to `TestContext`, as well as various overloads to the `MarkupMatches` methods, that also takes a `RenderFragment` as the expected value.
+
+  The difference between the generic `Render` method and the non-generic one is that the generic returns an `IRenderedComponent<TComponent>`, whereas the non-generic one returns a `IRenderedFragment`.
+
+  Calling `Render<TComponent>(RenderFragent)` is equivalent to calling `Render(RenderFragment).FindComponent<TComponent>()`, e.g. it returns the first component in the render tree of type `TComponent`. This is different from the `RenderComponent<TComponent>()` method, where `TComponent` _is_ the root component of the render tree.
+
+  The main usecase for these are when writing tests inside .razor files. Here the inline syntax for declaring render fragments make these methods very useful.
+
+  For example, to tests the `<Counter>` page/component that is part of new Blazor apps, do the following (inside a `CounterTest.razor` file):
+
+  ```cshtml
+  @code
+  {
+    [Fact]
+    public void Counter_Increments_When_Button_Is_Clicked()
+    {
+      using var ctx = new TestContext();
+      var cut = ctx.Render(@<Counter />);
+
+      cut.Find("button").Click();
+
+      cut.Find("p").MarkupMatches(@<p>Current count: 1</p>);
+    }
+  }
+  ```
+
+  Note: This example uses xUnit, but NUnit or MSTest works equally well.
+
+  In addition to the new `Render` methods, a empty `BuildRenderTree` method has been added to the `TestContext` type. This makes it possible to inherit from the `TestContext` type in test components, removing the need for newing up the `TestContext` in each test.
+
+  This means the test component above ends up looking like this:
+
+  ```cshtml
+  @inherts TestContext
+  @code
+  {
+    [Fact]
+    public void Counter_Increments_When_Button_Is_Clicked()
+    {
+      var cut = Render(@<Counter />);
+
+      cut.Find("button").Click();
+
+      cut.Find("p").MarkupMatches(@<p>Current count: 1</p>);
+    }
+  }
+  ```
+
+  Tip: If you have multiple test components in the same folder, you can add a `_Imports.razor` file inside it and add the `@inherits TestContext` statement in that, removing the need to add it to every test component.
+
+  By [@egil](https://github.com/egil) in [#262](https://github.com/egil/bUnit/pull/262).
+
 ### Changed
 List of changes in existing functionality.
 

--- a/src/bunit.core/RazorTesting/FragmentContainer.cs
+++ b/src/bunit.core/RazorTesting/FragmentContainer.cs
@@ -9,7 +9,7 @@ namespace Bunit.RazorTesting
 	/// when a fragment is rendered inside a test contexts render tree.
 	/// It is primarily used to be able to find the starting point to return.
 	/// </summary>
-	internal sealed class FragmentContainer : ComponentBase
+	public sealed class FragmentContainer : ComponentBase
 	{
 		/// <summary>
 		/// The content to wrap.
@@ -25,7 +25,7 @@ namespace Bunit.RazorTesting
 		/// <summary>
 		/// Wraps the <paramref name="wrappingTarget"/> in a <see cref="FragmentContainer"/>.
 		/// </summary>
-		internal static RenderFragment Wrap(RenderFragment wrappingTarget)
+		public static RenderFragment Wrap(RenderFragment wrappingTarget)
 		{
 			return builder =>
 			{

--- a/src/bunit.core/TestContextBase.cs
+++ b/src/bunit.core/TestContextBase.cs
@@ -1,7 +1,5 @@
 using System;
-using Bunit.RazorTesting;
 using Bunit.Rendering;
-using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bunit
@@ -51,46 +49,6 @@ namespace Bunit
 		protected TestContextBase()
 		{
 			Services = new TestServiceProvider();			
-		}
-
-		/// <summary>
-		/// Renders a component, declared in the <paramref name="renderFragment"/>, inside the <see cref="RenderTree"/>.
-		/// </summary>
-		/// <typeparam name="TComponent">The type of component to render.</typeparam>
-		/// <param name="renderFragment">The <see cref="RenderFragmentBase"/> that contains a declaration of the component.</param>
-		/// <returns>A <see cref="IRenderedComponentBase{TComponent}"/>.</returns>
-		protected IRenderedComponentBase<TComponent> RenderComponentBase<TComponent>(RenderFragment renderFragment) where TComponent : IComponent
-		{
-			// Wrap TComponent in any layout components added to the test context.
-			// If one of the layout components is the same type as TComponent,
-			// make sure to return the rendered component, not the layout component.			
-			var resultBase = Renderer.RenderFragment(RenderTree.Wrap(renderFragment));
-
-			// This ensures that the correct component is returned, in case an added layout component
-			// is of type TComponent.
-			var renderTreeTComponentCount = RenderTree.GetCountOf<TComponent>();
-			var result = renderTreeTComponentCount > 0
-				? Renderer.FindComponents<TComponent>(resultBase)[renderTreeTComponentCount]
-				: Renderer.FindComponent<TComponent>(resultBase);
-
-			return result;
-		}
-
-		/// <summary>
-		/// Renders a fragment, declared in the <paramref name="renderFragment"/>, inside the <see cref="RenderTree"/>.
-		/// </summary>
-		/// <param name="renderFragment">The <see cref="RenderFragmentBase"/> to render.</param>
-		/// <returns>A <see cref="IRenderedFragmentBase"/>.</returns>
-		protected IRenderedFragmentBase RenderFragmentBase(RenderFragment renderFragment)
-		{
-			// Wrap fragment in a FragmentContainer so the start of the test supplied
-			// razor fragment can be found after, and then wrap in any layout components
-			// added to the test context.		
-			var wrappedInFragmentContainer = FragmentContainer.Wrap(renderFragment);
-			var wrappedInRenderTree = RenderTree.Wrap(wrappedInFragmentContainer);
-			var resultBase = Renderer.RenderFragment(wrappedInRenderTree);
-
-			return Renderer.FindComponent<FragmentContainer>(resultBase);
 		}
 
 		/// <inheritdoc/>

--- a/src/bunit.core/TestServiceProvider.cs
+++ b/src/bunit.core/TestServiceProvider.cs
@@ -13,12 +13,7 @@ namespace Bunit
 	{
 		private readonly IServiceCollection _serviceCollection;
 		private ServiceProvider? _serviceProvider;
-
-		/// <summary>
-		/// Gets a reusable default test service provider.
-		/// </summary>
-		public static readonly IServiceProvider Default = new TestServiceProvider(new ServiceCollection(), true);
-
+		
 		/// <summary>
 		/// Gets whether this <see cref="TestServiceProvider"/> has been initialized, and 
 		/// no longer will accept calls to the <c>AddService</c>'s methods.

--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using AngleSharp.Dom;
 using Bunit.Asserting;
 using Bunit.Diffing;
+using Bunit.Extensions;
 using Bunit.Rendering;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -301,8 +302,8 @@ namespace Bunit
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
-			var testContext = actual.Services.GetRequiredService<TestContext>();
-			var renderedFragment = testContext.Render(expected);
+			var testContext = actual.Services.GetRequiredService<TestContextBase>();
+			var renderedFragment = testContext.RenderInsideRenderTree(expected);
 			MarkupMatches(actual, renderedFragment, userMessage);
 		}
 
@@ -323,7 +324,7 @@ namespace Bunit
 				throw new ArgumentNullException(nameof(expected));
 
 			var testContext = actual.GetTestContext() ?? new TestContext();
-			var renderedFragment = testContext.Render(expected);
+			var renderedFragment = testContext.RenderInsideRenderTree(expected);
 			MarkupMatches(actual, renderedFragment, userMessage);
 		}
 
@@ -344,7 +345,7 @@ namespace Bunit
 				throw new ArgumentNullException(nameof(expected));
 
 			var testContext = actual.GetTestContext() ?? new TestContext();
-			var renderedFragment = testContext.Render(expected);
+			var renderedFragment = testContext.RenderInsideRenderTree(expected);
 			MarkupMatches(actual, renderedFragment, userMessage);
 		}
 

--- a/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
+++ b/src/bunit.web/Asserting/MarkupMatchesAssertExtensions.cs
@@ -3,6 +3,7 @@ using AngleSharp.Dom;
 using Bunit.Asserting;
 using Bunit.Diffing;
 using Bunit.Rendering;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bunit
@@ -23,6 +24,11 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this string actual, string expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
 			using var parser = new BunitHtmlParser();
 			var actualNodes = parser.Parse(actual);
 			var expectedNodes = parser.Parse(expected);
@@ -31,15 +37,17 @@ namespace Bunit
 
 		/// <summary>
 		/// Verifies that the rendered markup from the <paramref name="actual"/> markup fragment matches
-		/// the <paramref name="expected"/> <see cref="IRenderedFragmentBase"/>, using the <see cref="HtmlComparer"/> type.
+		/// the <paramref name="expected"/> <see cref="IRenderedFragment"/>, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
 		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
 		/// <param name="actual">The markup fragment to verify.</param>
-		/// <param name="expected">The expected <see cref="IRenderedFragmentBase"/>.</param>
+		/// <param name="expected">The expected <see cref="IRenderedFragment"/>.</param>
 		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
 		[AssertionMethod]
 		public static void MarkupMatches(this string actual, IRenderedFragment expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
@@ -58,6 +66,8 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this string actual, INodeList expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
@@ -76,6 +86,8 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this string actual, INode expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
 			if (expected is null)
 				throw new ArgumentNullException(nameof(expected));
 
@@ -84,7 +96,7 @@ namespace Bunit
 		}
 
 		/// <summary>
-		/// Verifies that the rendered markup from the <paramref name="actual"/> <see cref="IRenderedFragmentBase"/> matches
+		/// Verifies that the rendered markup from the <paramref name="actual"/> <see cref="IRenderedFragment"/> matches
 		/// the <paramref name="expected"/> markup, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
 		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
@@ -104,8 +116,8 @@ namespace Bunit
 		}
 
 		/// <summary>
-		/// Verifies that the rendered markup from the <paramref name="actual"/> <see cref="IRenderedFragmentBase"/> matches
-		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragmentBase"/>, using the <see cref="HtmlComparer"/> type.
+		/// Verifies that the rendered markup from the <paramref name="actual"/> <see cref="IRenderedFragment"/> matches
+		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragment"/>, using the <see cref="HtmlComparer"/> type.
 		/// </summary>
 		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
 		/// <param name="actual">The rendered fragment to verify.</param>
@@ -124,7 +136,7 @@ namespace Bunit
 
 		/// <summary>
 		/// Verifies that the <paramref name="actual"/> <see cref="INodeList"/> matches
-		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragmentBase"/>, using the <see cref="HtmlComparer"/> 
+		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragment"/>, using the <see cref="HtmlComparer"/> 
 		/// type.
 		/// </summary>
 		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
@@ -144,7 +156,7 @@ namespace Bunit
 
 		/// <summary>
 		/// Verifies that the <paramref name="actual"/> <see cref="INode"/> matches
-		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragmentBase"/>, using the <see cref="HtmlComparer"/> 
+		/// the rendered markup from the <paramref name="expected"/> <see cref="IRenderedFragment"/>, using the <see cref="HtmlComparer"/> 
 		/// type.
 		/// </summary>
 		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
@@ -176,6 +188,8 @@ namespace Bunit
 		{
 			if (actual is null)
 				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
 
 			var expectedNodes = expected.ToNodeList(actual.GetHtmlParser());
 			actual.MarkupMatches(expectedNodes, userMessage);
@@ -195,6 +209,8 @@ namespace Bunit
 		{
 			if (actual is null)
 				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
 
 			var expectedNodes = expected.ToNodeList(actual.GetHtmlParser());
 			actual.MarkupMatches(expectedNodes, userMessage);
@@ -212,6 +228,11 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this INodeList actual, INodeList expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
 			var diffs = actual.CompareTo(expected);
 
 			if (diffs.Count != 0)
@@ -230,6 +251,11 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this INodeList actual, INode expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
 			var diffs = actual.CompareTo(expected);
 
 			if (diffs.Count != 0)
@@ -248,10 +274,78 @@ namespace Bunit
 		[AssertionMethod]
 		public static void MarkupMatches(this INode actual, INodeList expected, string? userMessage = null)
 		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
 			var diffs = actual.CompareTo(expected);
 
 			if (diffs.Count != 0)
 				throw new HtmlEqualException(diffs, expected, actual, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the rendered markup from the <paramref name="actual"/> <see cref="IRenderedFragment"/> matches
+		/// the rendered markup from the <paramref name="expected"/> <see cref="RenderFragment"/>, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actual">The rendered fragment to verify.</param>
+		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this IRenderedFragment actual, RenderFragment expected, string? userMessage = null)
+		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			var testContext = actual.Services.GetRequiredService<TestContext>();
+			var renderedFragment = testContext.Render(expected);
+			MarkupMatches(actual, renderedFragment, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the markup from the <paramref name="actual"/> matches
+		/// the rendered markup from the <paramref name="expected"/> <see cref="RenderFragment"/>, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actual">The markup to verify.</param>
+		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this INode actual, RenderFragment expected, string? userMessage = null)
+		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			var testContext = actual.GetTestContext() ?? new TestContext();
+			var renderedFragment = testContext.Render(expected);
+			MarkupMatches(actual, renderedFragment, userMessage);
+		}
+
+		/// <summary>
+		/// Verifies that the markup from the <paramref name="actual"/> matches
+		/// the rendered markup from the <paramref name="expected"/> <see cref="RenderFragment"/>, using the <see cref="HtmlComparer"/> type.
+		/// </summary>
+		/// <exception cref="HtmlEqualException">Thrown when the <paramref name="actual"/> markup does not match the <paramref name="expected"/> markup.</exception>
+		/// <param name="actual">The markup to verify.</param>
+		/// <param name="expected">The render fragment whose output to compare against.</param>
+		/// <param name="userMessage">A custom user message to display in case the verification fails.</param>
+		[AssertionMethod]
+		public static void MarkupMatches(this INodeList actual, RenderFragment expected, string? userMessage = null)
+		{
+			if (actual is null)
+				throw new ArgumentNullException(nameof(actual));
+			if (expected is null)
+				throw new ArgumentNullException(nameof(expected));
+
+			var testContext = actual.GetTestContext() ?? new TestContext();
+			var renderedFragment = testContext.Render(expected);
+			MarkupMatches(actual, renderedFragment, userMessage);
 		}
 
 		private static INodeList ToNodeList(this string markup, BunitHtmlParser? htmlParser)

--- a/src/bunit.web/Extensions/Internal/AngleSharpExtensions.cs
+++ b/src/bunit.web/Extensions/Internal/AngleSharpExtensions.cs
@@ -71,9 +71,9 @@ namespace Bunit
 		/// </summary>
 		/// <param name="node"></param>
 		/// <returns>The <see cref="TestContext"/> or null if not found.</returns>
-		public static TestContext? GetTestContext(this INode? node)
+		public static TestContextBase? GetTestContext(this INode? node)
 		{
-			return node?.Owner.Context.GetService<TestContext>();
+			return node?.Owner.Context.GetService<TestContextBase>();
 		}
 
 		/// <summary>
@@ -82,7 +82,7 @@ namespace Bunit
 		/// </summary>
 		/// <param name="nodes"></param>
 		/// <returns>The <see cref="TestContext"/> or null if not found.</returns>
-		public static TestContext? GetTestContext(this INodeList nodes)
+		public static TestContextBase? GetTestContext(this INodeList nodes)
 		{
 			return nodes?.Length > 0 ? nodes[0].GetTestContext() : null;
 		}

--- a/src/bunit.web/Extensions/Internal/AngleSharpExtensions.cs
+++ b/src/bunit.web/Extensions/Internal/AngleSharpExtensions.cs
@@ -66,6 +66,28 @@ namespace Bunit
 		}
 
 		/// <summary>
+		/// Gets the <see cref="TestContext"/> stored in the <paramref name="node"/>s
+		/// owning context, if one is available. 
+		/// </summary>
+		/// <param name="node"></param>
+		/// <returns>The <see cref="TestContext"/> or null if not found.</returns>
+		public static TestContext? GetTestContext(this INode? node)
+		{
+			return node?.Owner.Context.GetService<TestContext>();
+		}
+
+		/// <summary>
+		/// Gets the <see cref="TestContext"/> stored in the <paramref name="nodes"/>s
+		/// owning context, if one is available. 
+		/// </summary>
+		/// <param name="nodes"></param>
+		/// <returns>The <see cref="TestContext"/> or null if not found.</returns>
+		public static TestContext? GetTestContext(this INodeList nodes)
+		{
+			return nodes?.Length > 0 ? nodes[0].GetTestContext() : null;
+		}
+
+		/// <summary>
 		/// Gets the parents of the <paramref name="element"/>, starting with
 		/// the <paramref name="element"/> itself.
 		/// </summary>

--- a/src/bunit.web/Extensions/TestContextExtensions.cs
+++ b/src/bunit.web/Extensions/TestContextExtensions.cs
@@ -1,0 +1,51 @@
+using Bunit.RazorTesting;
+using Microsoft.AspNetCore.Components;
+
+namespace Bunit.Extensions
+{
+	internal static class TestContextExtensions
+	{
+		/// <summary>
+		/// Renders a component, declared in the <paramref name="renderFragment"/>, inside the <see cref="TestContextBase.RenderTree"/>.
+		/// </summary>
+		/// <typeparam name="TComponent">The type of component to render.</typeparam>
+		/// <param name="testContext">Test context to use to render with.</param>
+		/// <param name="renderFragment">The <see cref="RenderInsideRenderTree"/> that contains a declaration of the component.</param>
+		/// <returns>A <see cref="IRenderedComponentBase{TComponent}"/>.</returns>
+		public static IRenderedComponent<TComponent> RenderInsideRenderTree<TComponent>(this TestContextBase testContext, RenderFragment renderFragment) where TComponent : IComponent
+		{
+			// Wrap TComponent in any layout components added to the test context.
+			// If one of the layout components is the same type as TComponent,
+			// make sure to return the rendered component, not the layout component.			
+			var resultBase = testContext.Renderer.RenderFragment(testContext.RenderTree.Wrap(renderFragment));
+
+			// This ensures that the correct component is returned, in case an added layout component
+			// is of type TComponent.
+			var renderTreeTComponentCount = testContext.RenderTree.GetCountOf<TComponent>();
+			var result = renderTreeTComponentCount > 0
+				? testContext.Renderer.FindComponents<TComponent>(resultBase)[renderTreeTComponentCount]
+				: testContext.Renderer.FindComponent<TComponent>(resultBase);
+
+			return (IRenderedComponent<TComponent>)result;
+		}
+
+		/// <summary>
+		/// Renders a fragment, declared in the <paramref name="renderFragment"/>, inside the <see cref="TestContextBase.RenderTree"/>.
+		/// </summary>
+		/// <param name="testContext">Test context to use to render with.</param>
+		/// <param name="renderFragment">The <see cref="RenderInsideRenderTree"/> to render.</param>
+		/// <returns>A <see cref="IRenderedFragmentBase"/>.</returns>
+		public static IRenderedFragment RenderInsideRenderTree(this TestContextBase testContext, RenderFragment renderFragment)
+		{
+			// Wrap fragment in a FragmentContainer so the start of the test supplied
+			// razor fragment can be found after, and then wrap in any layout components
+			// added to the test context.		
+			var wrappedInFragmentContainer = FragmentContainer.Wrap(renderFragment);
+			var wrappedInRenderTree = testContext.RenderTree.Wrap(wrappedInFragmentContainer);
+			var resultBase = testContext.Renderer.RenderFragment(wrappedInRenderTree);
+
+			return (IRenderedFragment)testContext.Renderer.FindComponent<FragmentContainer>(resultBase);
+		}
+
+	}
+}

--- a/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
+++ b/src/bunit.web/Extensions/TestServiceProviderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Bunit.Diffing;
+using Bunit.JSInterop;
 using Bunit.Rendering;
 using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Authorization;
@@ -21,7 +22,7 @@ namespace Bunit.Extensions
 		/// <summary>
 		/// Registers the default services required by the web <see cref="TestContext"/>.
 		/// </summary>
-		public static IServiceCollection AddDefaultTestContextServices(this IServiceCollection services)
+		public static IServiceCollection AddDefaultTestContextServices(this IServiceCollection services, TestContextBase testContext, BunitJSInterop jsInterop)
 		{
 			// Placeholders and defaults for common Blazor services
 			services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
@@ -31,7 +32,12 @@ namespace Bunit.Extensions
 			services.AddSingleton<HttpClient, PlaceholderHttpClient>();
 			services.AddSingleton<IStringLocalizer, PlaceholderStringLocalization>();
 
+			// bUnits fake JSInterop
+			jsInterop.AddBuiltInJSRuntimeInvocationHandlers();
+			services.AddSingleton<IJSRuntime>(jsInterop.JSRuntime);
+
 			// bUnit specific services
+			services.AddSingleton<TestContextBase>(testContext);
 			services.AddSingleton<ITestRenderer, WebTestRenderer>();
 			services.AddSingleton<HtmlComparer>();
 			services.AddSingleton<BunitHtmlParser>();

--- a/src/bunit.web/IRenderedFragment.cs
+++ b/src/bunit.web/IRenderedFragment.cs
@@ -48,7 +48,5 @@ namespace Bunit
 		/// the snapshot and the rendered markup at that time.
 		/// </summary>
 		void SaveSnapshot();
-
-
 	}
 }

--- a/src/bunit.web/RazorTesting/Fixture.cs
+++ b/src/bunit.web/RazorTesting/Fixture.cs
@@ -42,9 +42,7 @@ namespace Bunit
 		/// </summary>
 		public Fixture()
 		{
-			JSInterop.AddBuiltInJSRuntimeInvocationHandlers();
-			Services.AddSingleton<IJSRuntime>(JSInterop.JSRuntime);
-			Services.AddDefaultTestContextServices();
+			Services.AddDefaultTestContextServices(this, JSInterop);
 		}
 
 		/// <summary>
@@ -170,7 +168,6 @@ namespace Bunit
 		/// <inheritdoc/>
 		protected override Task Run()
 		{
-			Services.AddDefaultTestContextServices();
 			return base.Run(this);
 		}
 	}

--- a/src/bunit.web/RazorTesting/Fixture.cs
+++ b/src/bunit.web/RazorTesting/Fixture.cs
@@ -142,12 +142,12 @@ namespace Bunit
 
 		private IRenderedComponent<TComponent> Factory<TComponent>(RenderFragment fragment) where TComponent : IComponent
 		{
-			return (IRenderedComponent<TComponent>)RenderComponentBase<TComponent>(fragment);
+			return this.RenderInsideRenderTree<TComponent>(fragment);
 		}
 
 		private IRenderedFragment Factory(RenderFragment fragment)
 		{
-			return (IRenderedFragment)RenderFragmentBase(fragment);
+			return this.RenderInsideRenderTree(fragment);
 		}
 
 		private static IRenderedComponent<TComponent> TryCastTo<TComponent>(IRenderedFragment target, [System.Runtime.CompilerServices.CallerMemberName] string sourceMethod = "") where TComponent : IComponent

--- a/src/bunit.web/RazorTesting/SnapshotTest.cs
+++ b/src/bunit.web/RazorTesting/SnapshotTest.cs
@@ -53,9 +53,7 @@ namespace Bunit
 		/// </summary>
 		public SnapshotTest()
 		{
-			JSInterop.AddBuiltInJSRuntimeInvocationHandlers();
-			Services.AddSingleton<IJSRuntime>(JSInterop.JSRuntime);
-			Services.AddDefaultTestContextServices();
+			Services.AddDefaultTestContextServices(this, JSInterop);
 		}
 
 		/// <inheritdoc/>
@@ -79,7 +77,7 @@ namespace Bunit
 
 		private void VerifySnapshot(string inputHtml, string expectedHtml)
 		{
-			using var parser = new BunitHtmlParser();
+			var parser = Services.GetRequiredService<BunitHtmlParser>();
 			var inputNodes = parser.Parse(inputHtml);
 			var expectedNodes = parser.Parse(expectedHtml);
 

--- a/src/bunit.web/RazorTesting/SnapshotTest.cs
+++ b/src/bunit.web/RazorTesting/SnapshotTest.cs
@@ -68,10 +68,10 @@ namespace Bunit
 			if (SetupAsync is not null)
 				await TryRunAsync(SetupAsync, this).ConfigureAwait(false);
 
-			var renderedTestInput = (IRenderedFragment)RenderFragmentBase(TestInput!);
+			var renderedTestInput = this.RenderInsideRenderTree(TestInput!);
 			var inputHtml = renderedTestInput.Markup;
 
-			var renderedExpectedRender = (IRenderedFragment)RenderFragmentBase(ExpectedOutput!);
+			var renderedExpectedRender = this.RenderInsideRenderTree(ExpectedOutput!);
 			var expectedHtml = renderedExpectedRender.Markup;
 
 			VerifySnapshot(inputHtml, expectedHtml);

--- a/src/bunit.web/Rendering/BunitHtmlParser.cs
+++ b/src/bunit.web/Rendering/BunitHtmlParser.cs
@@ -36,10 +36,11 @@ namespace Bunit.Rendering
 		/// Creates an instance of the parser with a AngleSharp context 
 		/// with the <paramref name="testRenderer"/> registered.
 		/// </summary>
-		public BunitHtmlParser(ITestRenderer testRenderer, HtmlComparer htmlComparer)
+		public BunitHtmlParser(ITestRenderer testRenderer, HtmlComparer htmlComparer, TestContext testContext)
 			: this(Configuration.Default.WithCss()
 				  .With(testRenderer ?? throw new ArgumentNullException(nameof(testRenderer)))
-				  .With(htmlComparer ?? throw new ArgumentNullException(nameof(htmlComparer))))
+				  .With(htmlComparer ?? throw new ArgumentNullException(nameof(htmlComparer)))
+				  .With(testContext ?? throw new ArgumentNullException(nameof(testContext))))
 		{ }
 
 		private BunitHtmlParser(IConfiguration angleSharpConfiguration)

--- a/src/bunit.web/Rendering/BunitHtmlParser.cs
+++ b/src/bunit.web/Rendering/BunitHtmlParser.cs
@@ -36,7 +36,7 @@ namespace Bunit.Rendering
 		/// Creates an instance of the parser with a AngleSharp context 
 		/// with the <paramref name="testRenderer"/> registered.
 		/// </summary>
-		public BunitHtmlParser(ITestRenderer testRenderer, HtmlComparer htmlComparer, TestContext testContext)
+		public BunitHtmlParser(ITestRenderer testRenderer, HtmlComparer htmlComparer, TestContextBase testContext)
 			: this(Configuration.Default.WithCss()
 				  .With(testRenderer ?? throw new ArgumentNullException(nameof(testRenderer)))
 				  .With(htmlComparer ?? throw new ArgumentNullException(nameof(htmlComparer)))

--- a/src/bunit.web/TestContext.cs
+++ b/src/bunit.web/TestContext.cs
@@ -23,10 +23,7 @@ namespace Bunit
 		/// </summary>
 		public TestContext()
 		{
-			Services.AddSingleton(this);
-			JSInterop.AddBuiltInJSRuntimeInvocationHandlers();
-			Services.AddSingleton(JSInterop.JSRuntime);
-			Services.AddDefaultTestContextServices();
+			Services.AddDefaultTestContextServices(this, JSInterop);
 		}
 
 		/// <summary>

--- a/src/bunit.web/TestContext.cs
+++ b/src/bunit.web/TestContext.cs
@@ -23,8 +23,9 @@ namespace Bunit
 		/// </summary>
 		public TestContext()
 		{
+			Services.AddSingleton(this);
 			JSInterop.AddBuiltInJSRuntimeInvocationHandlers();
-			Services.AddSingleton<IJSRuntime>(JSInterop.JSRuntime);
+			Services.AddSingleton(JSInterop.JSRuntime);
 			Services.AddDefaultTestContextServices();
 		}
 
@@ -37,7 +38,7 @@ namespace Bunit
 		public virtual IRenderedComponent<TComponent> RenderComponent<TComponent>(params ComponentParameter[] parameters) where TComponent : IComponent
 		{
 			var renderFragment = new ComponentParameterCollection { parameters }.ToRenderFragment<TComponent>();
-			return (IRenderedComponent<TComponent>)RenderComponentBase<TComponent>(renderFragment);
+			return Render<TComponent>(renderFragment);
 		}
 
 		/// <summary>
@@ -49,7 +50,33 @@ namespace Bunit
 		public virtual IRenderedComponent<TComponent> RenderComponent<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder) where TComponent : IComponent
 		{
 			var renderFragment = new ComponentParameterCollectionBuilder<TComponent>(parameterBuilder).Build().ToRenderFragment<TComponent>();
-			return (IRenderedComponent<TComponent>)RenderComponentBase<TComponent>(renderFragment);
+			return Render<TComponent>(renderFragment);
 		}
+
+		/// <summary>
+		/// Renders the <paramref name="renderFragment"/> and returns the first <typeparamref name="TComponent"/> in the resulting render tree.
+		/// </summary>
+		/// <remarks>
+		/// Calling this method is equivalent to calling <c>Render(renderFragment).FindComponent&lt;TComponent&gt;()</c>.
+		/// </remarks>
+		/// <typeparam name="TComponent">The type of component to find in the render tree.</typeparam>
+		/// <param name="renderFragment">The render fragment to render.</param>
+		/// <returns>The <see cref="IRenderedComponent{TComponent}"/>.</returns>
+		public virtual IRenderedComponent<TComponent> Render<TComponent>(RenderFragment renderFragment) where TComponent : IComponent
+			=> this.RenderInsideRenderTree<TComponent>(renderFragment);
+
+		/// <summary>
+		/// Renders the <paramref name="renderFragment"/> and returns it as a <see cref="IRenderedFragment"/>.
+		/// </summary>
+		/// <param name="renderFragment">The render fragment to render.</param>
+		/// <returns>The <see cref="IRenderedFragment"/>.</returns>
+		public virtual IRenderedFragment Render(RenderFragment renderFragment)
+			=> this.RenderInsideRenderTree(renderFragment);
+
+		/// <summary>
+		/// Dummy method required to allow Blazors compiler to generate
+		/// C# from .razor files.
+		/// </summary>
+		protected virtual void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder) { }
 	}
 }

--- a/tests/bunit.core.tests/Rendering/TestRendererTest.cs
+++ b/tests/bunit.core.tests/Rendering/TestRendererTest.cs
@@ -73,17 +73,8 @@ namespace Bunit.Rendering
 		}
 	}
 
-	public class TestRendererTest
+	public class TestRendererTest : TestContext
 	{
-		private TestServiceProvider Services { get; }
-
-		public TestRendererTest()
-		{
-			Services = new TestServiceProvider();
-			Services.AddDefaultTestContextServices();
-			Services.AddSingleton<ITestRenderer, TestRenderer>();
-		}
-
 		[Fact(DisplayName = "RenderFragment re-throws exception from component")]
 		public void Test004()
 		{

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.cs
@@ -1,0 +1,100 @@
+using System;
+using AngleSharp.Dom;
+using Microsoft.AspNetCore.Components;
+using Shouldly;
+using Xunit;
+
+namespace Bunit.Asserting
+{
+	public class MarkupMatchesAssertExtensionsTest : TestContext
+	{
+		private const string ActualMarkup = "<p>FOO</p>";
+		private const string ExpectedMarkup = "<div>BAR</div>";
+		private static readonly RenderFragment ActualRenderFragment = b => b.AddMarkupContent(0, ActualMarkup);
+		private static readonly RenderFragment ExpectedRenderFragment = b => b.AddMarkupContent(0, ExpectedMarkup);
+		private IRenderedFragment ActualRenderedFragment => Render(ActualRenderFragment);
+		private IRenderedFragment ExpectedRenderedFragment => Render(ExpectedRenderFragment);
+		private INodeList ActualNodeList => ActualRenderedFragment.Nodes;
+		private INodeList ExpectedNodeList => ExpectedRenderedFragment.Nodes;
+		private INode ActualNode => ActualNodeList[0];
+		private INode ExpectedNode => ExpectedNodeList[0];
+
+
+		[Fact(DisplayName = "MarkupMatches with null arguments throws ArgumentNullException")]
+		public void Test001()
+		{
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(ExpectedMarkup));
+			Should.Throw<ArgumentNullException>(() => ActualMarkup.MarkupMatches(default(string)!));
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(default(string)!));
+
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(ExpectedRenderedFragment));
+			Should.Throw<ArgumentNullException>(() => ActualMarkup.MarkupMatches(default(IRenderedFragment)!));
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(default(IRenderedFragment)!));
+
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(ExpectedNodeList));
+			Should.Throw<ArgumentNullException>(() => ActualMarkup.MarkupMatches(default(INodeList)!));
+			Should.Throw<ArgumentNullException>(() => default(string)!.MarkupMatches(default(INodeList)!));
+
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(ExpectedNodeList));
+			Should.Throw<ArgumentNullException>(() => ActualNodeList.MarkupMatches(default(INodeList)!));
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(default(INodeList)!));
+
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(ExpectedNode));
+			Should.Throw<ArgumentNullException>(() => ActualNodeList.MarkupMatches(default(INode)!));
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(default(INode)!));
+
+			Should.Throw<ArgumentNullException>(() => default(INode)!.MarkupMatches(ExpectedNodeList));
+			Should.Throw<ArgumentNullException>(() => ActualNode.MarkupMatches(default(INodeList)!));
+			Should.Throw<ArgumentNullException>(() => default(INode)!.MarkupMatches(default(INodeList)!));
+
+			Should.Throw<ArgumentNullException>(() => default(IRenderedFragment)!.MarkupMatches(ExpectedRenderFragment));
+			Should.Throw<ArgumentNullException>(() => ActualRenderedFragment.MarkupMatches(default(RenderFragment)!));
+			Should.Throw<ArgumentNullException>(() => default(IRenderedFragment)!.MarkupMatches(default(RenderFragment)!));
+
+			Should.Throw<ArgumentNullException>(() => default(INode)!.MarkupMatches(ExpectedRenderFragment));
+			Should.Throw<ArgumentNullException>(() => ActualNode.MarkupMatches(default(RenderFragment)!));
+			Should.Throw<ArgumentNullException>(() => default(INode)!.MarkupMatches(default(RenderFragment)!));
+
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(ExpectedRenderFragment));
+			Should.Throw<ArgumentNullException>(() => ActualNodeList.MarkupMatches(default(RenderFragment)!));
+			Should.Throw<ArgumentNullException>(() => default(INodeList)!.MarkupMatches(default(RenderFragment)!));
+		}
+
+		[Fact(DisplayName = "MarkupMatches(string, string) correctly diffs markup")]
+		public void Test002()
+			=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedMarkup));
+
+		[Fact(DisplayName = "MarkupMatches(string, IRenderedFragment) correctly diffs markup")]
+		public void Test003()
+			=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedRenderedFragment));
+
+		[Fact(DisplayName = "MarkupMatches(string, INodeList) correctly diffs markup")]
+		public void Test004()
+			=> Should.Throw<HtmlEqualException>(() => ActualMarkup.MarkupMatches(ExpectedNodeList));
+
+		[Fact(DisplayName = "MarkupMatches(INodeList, INodeList) correctly diffs markup")]
+		public void Test005()
+			=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedNodeList));
+
+
+		[Fact(DisplayName = "MarkupMatches(INodeList, INode) correctly diffs markup")]
+		public void Test006()
+			=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedNode));
+
+		[Fact(DisplayName = "MarkupMatches(INode, INodeList) correctly diffs markup")]
+		public void Test007()
+			=> Should.Throw<HtmlEqualException>(() => ActualNode.MarkupMatches(ExpectedNodeList));
+
+		[Fact(DisplayName = "MarkupMatches(IRenderedFragment, RenderFragment) correctly diffs markup")]
+		public void Test008()
+			=> Should.Throw<HtmlEqualException>(() => ActualRenderedFragment.MarkupMatches(ExpectedRenderFragment));
+
+		[Fact(DisplayName = "MarkupMatches(INode, RenderFragment) correctly diffs markup")]
+		public void Test009()
+			=> Should.Throw<HtmlEqualException>(() => ActualNode.MarkupMatches(ExpectedRenderFragment));
+
+		[Fact(DisplayName = "MarkupMatches(INodeList, RenderFragment) correctly diffs markup")]
+		public void Test0010()
+			=> Should.Throw<HtmlEqualException>(() => ActualNodeList.MarkupMatches(ExpectedRenderFragment));
+	}
+}

--- a/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.net5.cs
+++ b/tests/bunit.web.tests/Asserting/MarkupMatchesAssertExtensionsTest.net5.cs
@@ -12,7 +12,7 @@ namespace Bunit
 {
 	public partial class MarkupMatchesAssertExtensionsTest : TestContext
 	{
-		[Fact(DisplayName = "MarkupMatches correctly ignores scoped css attributes")]
+		[Fact(DisplayName = "MarkupMatches correctly ignores scoped CSS attributes")]
 		public void Test_net5_001()
 		{
 			var cut = RenderComponent<ScopedCssElements>();

--- a/tests/bunit.web.tests/RazorTesting/FixtureTest.razor
+++ b/tests/bunit.web.tests/RazorTesting/FixtureTest.razor
@@ -199,3 +199,18 @@
 		}
 	}
 </Fixture>
+
+<Fixture Test="Test030" Description="Can raise events from markup rendered with Fixture">
+	<ComponentUnderTest>
+		<ClickCounter></ClickCounter>
+	</ComponentUnderTest>
+	@code
+	{
+		void Test030(Fixture f)
+		{
+			f.GetComponentUnderTest()
+				.Find("button")
+				.Click();
+		}
+	}
+</Fixture>

--- a/tests/bunit.web.tests/TestContextTest.cs
+++ b/tests/bunit.web.tests/TestContextTest.cs
@@ -1,6 +1,6 @@
-using System;
 using Bunit.TestAssets.SampleComponents;
 using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
 using Shouldly;
 using Xunit;
 
@@ -31,6 +31,66 @@ namespace Bunit
 		public void Test026()
 		{
 			Should.Throw<MissingMockStringLocalizationException>(() => RenderComponent<SimpleUsingLocalizer>());
+		}
+
+		[Fact(DisplayName = "Render() renders fragment inside RenderTreee")]
+		public void Test030()
+		{
+			RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
+			var cut = Render(b =>
+			{
+				b.OpenComponent<ReceivesCascadinValue>(0);
+				b.CloseComponent();
+			});
+
+			cut.FindComponent<ReceivesCascadinValue>()
+				.Instance
+				.Value
+				.ShouldBe("FOO");
+		}
+
+		[Fact(DisplayName = "Render<TComponent>() renders fragment inside RenderTreee")]
+		public void Test031()
+		{
+			RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
+			var cut = Render<ReceivesCascadinValue>(b =>
+			{
+				b.OpenComponent<ReceivesCascadinValue>(0);
+				b.CloseComponent();
+			});
+
+			cut.Instance
+				.Value
+				.ShouldBe("FOO");
+		}
+
+		[Fact(DisplayName = "RenderComponent<TComponent>(builder) renders TComponent inside RenderTreee")]
+		public void Test032()
+		{
+			RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
+			var cut = RenderComponent<ReceivesCascadinValue>(ps => ps.Add(p => p.Dummy, null));
+
+			cut.Instance
+				.Value
+				.ShouldBe("FOO");
+		}
+
+		[Fact(DisplayName = "RenderComponent<TComponent>(factories) renders TComponent inside RenderTreee")]
+		public void Test033()
+		{
+			RenderTree.Add<CascadingValue<string>>(ps => ps.Add(p => p.Value, "FOO"));
+			var cut = RenderComponent<ReceivesCascadinValue>(("Dummy", null));
+
+			cut.Instance
+				.Value
+				.ShouldBe("FOO");
+		}
+
+		class ReceivesCascadinValue : ComponentBase
+		{
+			[CascadingParameter] public string? Value { get; set; }
+
+			[Parameter] public object? Dummy { get; set; }
 		}
 	}
 }

--- a/tests/bunit.web.tests/TestContextTest.cs
+++ b/tests/bunit.web.tests/TestContextTest.cs
@@ -86,6 +86,14 @@ namespace Bunit
 				.ShouldBe("FOO");
 		}
 
+		[Fact(DisplayName = "Can raise events from markup rendered with TestContext")]
+		public void Test040()
+		{
+			RenderComponent<ClickCounter>()
+				.Find("button")
+				.Click();
+		}
+
 		class ReceivesCascadinValue : ComponentBase
 		{
 			[CascadingParameter] public string? Value { get; set; }


### PR DESCRIPTION
This PR adds support for cleaner razor based tests by making it possible for TestContext type to render RenderFragment's. This allows us to pass RenderFragments created inline in .razor files directly to the TestContext.

Also added support for passing RenderFragments to MarkupMatches' expected argument. This looks like this in practice, e.g. in a `CounterTest.razor` file:

```razor
@inherits TestContext
@code
{
    [Fact]
    public void Test()
    {
        var cut = Render(@<Counter />);
        cut.Find("button").Click();
        cut.Find("p").MarkupMatches(@<p>Current count: 1</p>);
    }
}
```

### PR meta checklist
- [x] Pull request is targeting at `DEV` branch.
- [x] Pull request is linked to all related issues, if any.
- [x] I have read the _CONTRIBUTING.md_ document.

### Content checklist
- [x] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [x] I have added, updated or removed tests to according to my changes.
  - [x] All tests passed.
