### PR TITLE
Implemented `IJSInProcessRuntime` and `IJSUnmarshalledRuntime` interf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The following section list all changes in 1.0.0 preview 01.
 ### Added
 List of new features.
 
+- Added support for casting `BUnitJSRuntime` to `IJSInProcessRuntime` and `IJSUnmarshalledRuntime`. By [@KristofferStrube](https://github.com/KristofferStrube) in [#279](https://github.com/egil/bUnit/pull/279)
+
 - Added support for triggering `@ontoggle` event handlers through a dedicated `Toggle()` method. By [@egil](https://github.com/egil) in [#256](https://github.com/egil/bUnit/pull/256).
 
 - Added out of the box support for `<Virtualize>` component. When a `<Virtualize>` component is used in a component under test, it's JavaScript interop-calls are faked by bUnits JSInterop, and it should result in all items being rendered immediately. By [@egil](https://github.com/egil) in [#240](https://github.com/egil/bUnit/issues/240).

--- a/src/bunit.web/JSInterop/BunitJSInterop.cs
+++ b/src/bunit.web/JSInterop/BunitJSInterop.cs
@@ -180,9 +180,11 @@ namespace Bunit
 			return result;
 		}
 
-		#if NET5_0
+
+		[SuppressMessage("Design", "CA2012:ValueTask instances should not have their result directly accessed unless the instance has already completed.", Justification = "The ValueTask always wraps a Task object.")]
+#if NET5_0
 		private class BUnitJSRuntime : IJSRuntime, IJSInProcessRuntime, IJSUnmarshalledRuntime
-		#else
+#else
 		private class BUnitJSRuntime : IJSRuntime, IJSInProcessRuntime
 		#endif
 		{

--- a/src/bunit.web/JSInterop/BunitJSInterop.cs
+++ b/src/bunit.web/JSInterop/BunitJSInterop.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -179,7 +180,11 @@ namespace Bunit
 			return result;
 		}
 
-		private class BUnitJSRuntime : IJSRuntime
+		#if NET5_0
+		private class BUnitJSRuntime : IJSRuntime, IJSInProcessRuntime, IJSUnmarshalledRuntime
+		#else
+		private class BUnitJSRuntime : IJSRuntime, IJSInProcessRuntime
+		#endif
 		{
 			private readonly BunitJSInterop _jsInterop;
 
@@ -187,6 +192,9 @@ namespace Bunit
 			{
 				_jsInterop = bunitJsInterop;
 			}
+
+			public TResult Invoke<TResult>(string identifier, params object?[]? args) =>
+				InvokeAsync<TResult>(identifier, args).GetAwaiter().GetResult();
 
 			public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
 				=> InvokeAsync<TValue>(identifier, default, args);
@@ -198,6 +206,18 @@ namespace Bunit
 
 				return TryHandlePlannedInvocation<TValue>(invocation) ?? new ValueTask<TValue>(default(TValue)!);
 			}
+
+			public TResult InvokeUnmarshalled<TResult>(string identifier) =>
+				InvokeAsync<TResult>(identifier, null).GetAwaiter().GetResult();
+
+			public TResult InvokeUnmarshalled<T0, TResult>(string identifier, [DisallowNull] T0 arg0) =>
+				InvokeAsync<TResult>(identifier, new object[1] {arg0}).GetAwaiter().GetResult();
+
+			public TResult InvokeUnmarshalled<T0, T1, TResult>(string identifier, [DisallowNull] T0 arg0, [DisallowNull] T1 arg1) =>
+				InvokeAsync<TResult>(identifier, new object[2] { arg0, arg1 }).GetAwaiter().GetResult();
+
+			public TResult InvokeUnmarshalled<T0, T1, T2, TResult>(string identifier, [DisallowNull] T0 arg0, [DisallowNull] T1 arg1, [DisallowNull] T2 arg2) =>
+				InvokeAsync<TResult>(identifier, new object[3] { arg0, arg1, arg2 }).GetAwaiter().GetResult();
 
 			private ValueTask<TValue>? TryHandlePlannedInvocation<TValue>(JSRuntimeInvocation invocation)
 			{

--- a/src/bunit.web/JSInterop/BunitJSInterop.cs
+++ b/src/bunit.web/JSInterop/BunitJSInterop.cs
@@ -210,16 +210,16 @@ namespace Bunit
 			}
 
 			public TResult InvokeUnmarshalled<TResult>(string identifier) =>
-				InvokeAsync<TResult>(identifier, null).GetAwaiter().GetResult();
+				InvokeAsync<TResult>(identifier, Array.Empty<object?>()).GetAwaiter().GetResult();
 
-			public TResult InvokeUnmarshalled<T0, TResult>(string identifier, [DisallowNull] T0 arg0) =>
-				InvokeAsync<TResult>(identifier, new object[1] {arg0}).GetAwaiter().GetResult();
+			public TResult InvokeUnmarshalled<T0, TResult>(string identifier, T0 arg0) =>
+				InvokeAsync<TResult>(identifier, new object?[] {arg0}).GetAwaiter().GetResult();
 
-			public TResult InvokeUnmarshalled<T0, T1, TResult>(string identifier, [DisallowNull] T0 arg0, [DisallowNull] T1 arg1) =>
-				InvokeAsync<TResult>(identifier, new object[2] { arg0, arg1 }).GetAwaiter().GetResult();
+			public TResult InvokeUnmarshalled<T0, T1, TResult>(string identifier, T0 arg0, T1 arg1) =>
+				InvokeAsync<TResult>(identifier, new object?[] { arg0, arg1 }).GetAwaiter().GetResult();
 
-			public TResult InvokeUnmarshalled<T0, T1, T2, TResult>(string identifier, [DisallowNull] T0 arg0, [DisallowNull] T1 arg1, [DisallowNull] T2 arg2) =>
-				InvokeAsync<TResult>(identifier, new object[3] { arg0, arg1, arg2 }).GetAwaiter().GetResult();
+			public TResult InvokeUnmarshalled<T0, T1, T2, TResult>(string identifier, T0 arg0, T1 arg1, T2 arg2) =>
+				InvokeAsync<TResult>(identifier, new object?[] { arg0, arg1, arg2 }).GetAwaiter().GetResult();
 
 			private ValueTask<TValue>? TryHandlePlannedInvocation<TValue>(JSRuntimeInvocation invocation)
 			{

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -525,6 +525,17 @@ namespace Bunit.JSInterop
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with zero arguments")]
+		public void Test050()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<object>(identifier); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBeEmpty();
+		}
 #endif
 	}
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -536,6 +536,40 @@ namespace Bunit.JSInterop
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBeEmpty();
 		}
+
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list and return the correct result.")]
+		public void Test051()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(Guid.NewGuid());
+
+			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result.")]
+		public void Test052()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(expectedResult);
+
+			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
+			actual.ShouldBe(expectedResult);
+		}
 #endif
 	}
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -451,7 +451,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Loose);
 
 			var _ = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>(identifier, args);
@@ -484,7 +483,7 @@ namespace Bunit.JSInterop
 			var identifier = "func";
 			var args = new[] { "bar", "baz" };
 
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>(identifier, args); });
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>(identifier, args));
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -435,5 +435,96 @@ namespace Bunit.JSInterop
 
 			actual.ShouldBe(expected);
 		}
+
+		[Fact(DisplayName = "Mock returns default value from IJSInProcessRuntime's invoke method in loose mode without invocation setup")]
+		public void Test043()
+		{
+			var sut = CreateSut(JSRuntimeMode.Loose);
+
+			var result = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>("ident", Array.Empty<object>());
+
+			result.ShouldBe(default);
+		}
+
+		[Fact(DisplayName = "After IJSInProcessRuntime invocation a invocation should be visible from the Invocations list")]
+		public void Test044()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Loose);
+
+			var _ = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>(identifier, args);
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "IJSInProcessRuntime invocations receive the result set in a planned invocation")]
+		public void Test045()
+		{
+			var identifier = "func";
+			var args = new[] { "bar", "baz" };
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>(identifier, args);
+			planned.SetResult(expectedResult);
+
+			var i = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<Guid>(identifier, args);
+
+			i.ShouldBe(expectedResult);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSInProcessRuntime invocation has not been setup")]
+		public void Test046()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar", "baz" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSInProcessRuntime)sut.JSRuntime).Invoke<object>(identifier, args); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+#if NET5_0
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with one argument")]
+		public void Test047()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, object>(identifier, "bar"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with two arguments")]
+		public void Test048()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar", "baz" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, object>(identifier, "bar", "baz"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with three arguments")]
+		public void Test049()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar", "baz", "bau" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, object>(identifier, "bar", "baz", "bau"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+#endif
 	}
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Bunit.JSInterop
 {
-	public class BunitJSInteropTest
+	public partial class BunitJSInteropTest
 	{
 		private static BunitJSInterop CreateSut(JSRuntimeMode mode) => new BunitJSInterop { Mode = mode };
 
@@ -488,88 +488,5 @@ namespace Bunit.JSInterop
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
-
-#if NET5_0
-		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with one argument")]
-		public void Test047()
-		{
-			var sut = CreateSut(JSRuntimeMode.Strict);
-			var identifier = "func";
-			var args = new[] { "bar" };
-
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, object>(identifier, "bar"); });
-			exception.Invocation.Identifier.ShouldBe(identifier);
-			exception.Invocation.Arguments.ShouldBe(args);
-		}
-
-		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with two arguments")]
-		public void Test048()
-		{
-			var sut = CreateSut(JSRuntimeMode.Strict);
-			var identifier = "func";
-			var args = new[] { "bar", "baz" };
-
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, object>(identifier, "bar", "baz"); });
-			exception.Invocation.Identifier.ShouldBe(identifier);
-			exception.Invocation.Arguments.ShouldBe(args);
-		}
-
-		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with three arguments")]
-		public void Test049()
-		{
-			var sut = CreateSut(JSRuntimeMode.Strict);
-			var identifier = "func";
-			var args = new[] { "bar", "baz", "bau" };
-
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, object>(identifier, "bar", "baz", "bau"); });
-			exception.Invocation.Identifier.ShouldBe(identifier);
-			exception.Invocation.Arguments.ShouldBe(args);
-		}
-
-		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with zero arguments")]
-		public void Test050()
-		{
-			var sut = CreateSut(JSRuntimeMode.Strict);
-			var identifier = "func";
-
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<object>(identifier); });
-			exception.Invocation.Identifier.ShouldBe(identifier);
-			exception.Invocation.Arguments.ShouldBeEmpty();
-		}
-
-		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list and return the correct result.")]
-		public void Test051()
-		{
-			var identifier = "fooFunc";
-			var args = new[] { "bar", "baz" };
-			using var cts = new CancellationTokenSource();
-			var sut = CreateSut(JSRuntimeMode.Strict);
-
-			var planned = sut.Setup<Guid>("fooFunc", args);
-			planned.SetResult(Guid.NewGuid());
-
-			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
-
-			var invocation = sut.Invocations[identifier].Single();
-			invocation.Identifier.ShouldBe(identifier);
-			invocation.Arguments.ShouldBe(args);
-		}
-
-		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result.")]
-		public void Test052()
-		{
-			var identifier = "fooFunc";
-			var args = new[] { "bar", "baz" };
-			using var cts = new CancellationTokenSource();
-			var sut = CreateSut(JSRuntimeMode.Strict);
-
-			var expectedResult = Guid.NewGuid();
-			var planned = sut.Setup<Guid>("fooFunc", args);
-			planned.SetResult(expectedResult);
-
-			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
-			actual.ShouldBe(expectedResult);
-		}
-#endif
 	}
 }

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
@@ -1,0 +1,98 @@
+#if NET5_0
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using Microsoft.JSInterop;
+using Shouldly;
+using Xunit;
+
+namespace Bunit.JSInterop
+{
+	public partial class BunitJSInteropTest
+	{
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with one argument")]
+		public void Test047()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, object>(identifier, "bar"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with two arguments")]
+		public void Test048()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar", "baz" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, object>(identifier, "bar", "baz"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with three arguments")]
+		public void Test049()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+			var args = new[] { "bar", "baz", "bau" };
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, object>(identifier, "bar", "baz", "bau"); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "Mock throws exception when in strict mode and IJSUnmarshalledRuntime invocation has not been setup with zero arguments")]
+		public void Test050()
+		{
+			var sut = CreateSut(JSRuntimeMode.Strict);
+			var identifier = "func";
+
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<object>(identifier); });
+			exception.Invocation.Identifier.ShouldBe(identifier);
+			exception.Invocation.Arguments.ShouldBeEmpty();
+		}
+
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list.")]
+		public void Test051()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(Guid.NewGuid());
+
+			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result.")]
+		public void Test052()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(expectedResult);
+
+			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
+			actual.ShouldBe(expectedResult);
+		}
+	}
+}
+#endif

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
@@ -20,7 +20,7 @@ namespace Bunit.JSInterop
 			var identifier = "func";
 			var args = new[] { "bar" };
 
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, object>(identifier, "bar"); });
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, object>(identifier, "bar"));
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
@@ -32,7 +32,7 @@ namespace Bunit.JSInterop
 			var identifier = "func";
 			var args = new[] { "bar", "baz" };
 
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, object>(identifier, "bar", "baz"); });
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, object>(identifier, "bar", "baz"));
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
@@ -44,7 +44,7 @@ namespace Bunit.JSInterop
 			var identifier = "func";
 			var args = new[] { "bar", "baz", "bau" };
 
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, object>(identifier, "bar", "baz", "bau"); });
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, object>(identifier, "bar", "baz", "bau"));
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBe(args);
 		}
@@ -55,7 +55,7 @@ namespace Bunit.JSInterop
 			var sut = CreateSut(JSRuntimeMode.Strict);
 			var identifier = "func";
 
-			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => { var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<object>(identifier); });
+			var exception = Should.Throw<JSRuntimeUnhandledInvocationException>(() => ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<object>(identifier));
 			exception.Invocation.Identifier.ShouldBe(identifier);
 			exception.Invocation.Arguments.ShouldBeEmpty();
 		}
@@ -65,7 +65,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar"};
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var planned = sut.Setup<Guid>("fooFunc", args);
@@ -83,7 +82,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var planned = sut.Setup<Guid>("fooFunc", args);
@@ -101,7 +99,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz", "boa" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var planned = sut.Setup<Guid>("fooFunc", args);
@@ -119,7 +116,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz", "boa" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var planned = sut.Setup<Guid>("fooFunc", args);
@@ -137,7 +133,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var expectedResult = Guid.NewGuid();
@@ -153,7 +148,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var expectedResult = Guid.NewGuid();
@@ -169,7 +163,6 @@ namespace Bunit.JSInterop
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz", "bao" };
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var expectedResult = Guid.NewGuid();
@@ -184,7 +177,6 @@ namespace Bunit.JSInterop
 		public void Test058()
 		{
 			var identifier = "fooFunc";
-			using var cts = new CancellationTokenSource();
 			var sut = CreateSut(JSRuntimeMode.Strict);
 
 			var expectedResult = Guid.NewGuid();

--- a/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
+++ b/tests/bunit.web.tests/JSInterop/BunitJSInteropTest.net5.cs
@@ -60,8 +60,26 @@ namespace Bunit.JSInterop
 			exception.Invocation.Arguments.ShouldBeEmpty();
 		}
 
-		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list.")]
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list when parsed one arguments.")]
 		public void Test051()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar"};
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(Guid.NewGuid());
+
+			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, Guid>(identifier, "bar");
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list when parsed two arguments.")]
+		public void Test052()
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz" };
@@ -78,8 +96,60 @@ namespace Bunit.JSInterop
 			invocation.Arguments.ShouldBe(args);
 		}
 
-		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result.")]
-		public void Test052()
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list when parsed three arguments.")]
+		public void Test053()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz", "boa" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(Guid.NewGuid());
+
+			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, Guid>(identifier, "bar", "baz", "boa");
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "After IJSUnmarshalledRuntime invocation a invocation should be visible from the Invocations list when parsed zero arguments.")]
+		public void Test054()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz", "boa" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(Guid.NewGuid());
+
+			var _ = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, Guid>(identifier, "bar", "baz", "boa");
+
+			var invocation = sut.Invocations[identifier].Single();
+			invocation.Identifier.ShouldBe(identifier);
+			invocation.Arguments.ShouldBe(args);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when parsed one arguments.")]
+		public void Test055()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(expectedResult);
+
+			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, Guid>(identifier, "bar");
+			actual.ShouldBe(expectedResult);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when parsed two arguments.")]
+		public void Test056()
 		{
 			var identifier = "fooFunc";
 			var args = new[] { "bar", "baz" };
@@ -91,6 +161,37 @@ namespace Bunit.JSInterop
 			planned.SetResult(expectedResult);
 
 			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, Guid>(identifier, "bar", "baz");
+			actual.ShouldBe(expectedResult);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when parsed three arguments.")]
+		public void Test057()
+		{
+			var identifier = "fooFunc";
+			var args = new[] { "bar", "baz", "bao" };
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>("fooFunc", args);
+			planned.SetResult(expectedResult);
+
+			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<string, string, string, Guid>(identifier, "bar", "baz", "bao");
+			actual.ShouldBe(expectedResult);
+		}
+
+		[Fact(DisplayName = "An IJSUnmarshalledRuntime invocation should return the correct result when parsed zero arguments.")]
+		public void Test058()
+		{
+			var identifier = "fooFunc";
+			using var cts = new CancellationTokenSource();
+			var sut = CreateSut(JSRuntimeMode.Strict);
+
+			var expectedResult = Guid.NewGuid();
+			var planned = sut.Setup<Guid>("fooFunc");
+			planned.SetResult(expectedResult);
+
+			var actual = ((IJSUnmarshalledRuntime)sut.JSRuntime).InvokeUnmarshalled<Guid>(identifier);
 			actual.ShouldBe(expectedResult);
 		}
 	}


### PR DESCRIPTION
## Pull request description
Pull request for issue #222
I use `#IF NET5_0` in the middle of namespaces/classes to differentiate what can be implemented in the different versions. This might not follow the AspNetCore coding guidelines.

### PR meta checklist
- [X] Pull request is targeting at `DEV` branch.
- [X] I have read the _CONTRIBUTING.md_ document.
- [X] Pull request is linked to all related issues, if any.

### Content checklist
- [X] My code follows the code style of this project and AspNetCore coding guidelines.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have updated the appropriate sub section in the _CHANGELOG.md_.
- [X] I have added, updated or removed tests to according to my changes.
  - [X] All tests passed.
