### PR TITLE
feat: Add generic overloads for Find and WaitFor methods to support s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to **bUnit** will be documented in this file. The project ad
 ### Added
 
 - Added `FindByAllByLabel` to `bunit.web.query` package. By [@linkdotnet](https://github.com/linkdotnet).
+- Added generic overloads `Find{TComponent, TElement}` and `FindAll{TComponent, TElement}` to query for specific element types (e.g., `IHtmlInputElement`). By [@linkdotnet](https://github.com/linkdotnet).
+- Added generic overloads `WaitForElement{TComponent, TElement}` and `WaitForElements{TComponent, TElement}` to wait for specific element types. By [@linkdotnet](https://github.com/linkdotnet).
 
 ### Fixed
 

--- a/src/bunit/Extensions/WaitForHelpers/RenderedComponentWaitForHelperExtensions.WaitForElement.cs
+++ b/src/bunit/Extensions/WaitForHelpers/RenderedComponentWaitForHelperExtensions.WaitForElement.cs
@@ -34,6 +34,37 @@ public static partial class RenderedComponentWaitForHelperExtensions
 		=> WaitForElementCore(renderedComponent, cssSelector, timeout: timeout);
 
 	/// <summary>
+	/// Wait until an element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of element to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for the element.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout. See the inner exception for details.</exception>
+	/// <returns>The <typeparamref name="TElement"/>.</returns>
+	public static TElement WaitForElement<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementCore<TComponent, TElement>(renderedComponent, cssSelector, timeout: null);
+
+	/// <summary>
+	/// Wait until an element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of element to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for the element.</param>
+	/// <param name="timeout">The maximum time to wait for the element to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout. See the inner exception for details.</exception>
+	/// <returns>The <typeparamref name="TElement"/>.</returns>
+	public static TElement WaitForElement<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementCore<TComponent, TElement>(renderedComponent, cssSelector, timeout: timeout);
+
+	/// <summary>
 	/// Wait until at least one element matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
 	/// or the timeout is reached (default is one second).
 	/// </summary>
@@ -84,6 +115,70 @@ public static partial class RenderedComponentWaitForHelperExtensions
 		=> WaitForElementsCore(renderedComponent, cssSelector, matchElementCount: matchElementCount, timeout: timeout);
 
 	/// <summary>
+	/// Wait until at least one element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static IReadOnlyList<TElement> WaitForElements<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCore<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: null, timeout: null);
+
+	/// <summary>
+	/// Wait until exactly <paramref name="matchElementCount"/> element(s) of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="matchElementCount">The exact number of elements to that the <paramref name="cssSelector"/> should match.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static IReadOnlyList<TElement> WaitForElements<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, int matchElementCount)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCore<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: matchElementCount, timeout: null);
+
+	/// <summary>
+	/// Wait until at least one element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="timeout">The maximum time to wait for elements to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static IReadOnlyList<TElement> WaitForElements<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCore<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: null, timeout: timeout);
+
+	/// <summary>
+	/// Wait until exactly <paramref name="matchElementCount"/> element(s) of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="matchElementCount">The exact number of elements to that the <paramref name="cssSelector"/> should match.</param>
+	/// <param name="timeout">The maximum time to wait for elements to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static IReadOnlyList<TElement> WaitForElements<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, int matchElementCount, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCore<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: matchElementCount, timeout: timeout);
+
+	/// <summary>
 	/// Wait until an element matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
 	/// or the timeout is reached (default is one second).
 	/// </summary>
@@ -106,6 +201,37 @@ public static partial class RenderedComponentWaitForHelperExtensions
 	public static Task<IElement> WaitForElementAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan timeout)
 		where TComponent : IComponent
 		=> WaitForElementCoreAsync(renderedComponent, cssSelector, timeout: timeout);
+
+	/// <summary>
+	/// Wait until an element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of element to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for the element.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout. See the inner exception for details.</exception>
+	/// <returns>The <typeparamref name="TElement"/>.</returns>
+	public static Task<TElement> WaitForElementAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, timeout: null);
+
+	/// <summary>
+	/// Wait until an element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of element to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for the element.</param>
+	/// <param name="timeout">The maximum time to wait for the element to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout. See the inner exception for details.</exception>
+	/// <returns>The <typeparamref name="TElement"/>.</returns>
+	public static Task<TElement> WaitForElementAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, timeout: timeout);
 
 	/// <summary>
 	/// Wait until exactly <paramref name="matchElementCount"/> element(s) matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
@@ -157,12 +283,80 @@ public static partial class RenderedComponentWaitForHelperExtensions
 	/// <returns>The <see cref="IReadOnlyList{IElement}"/>.</returns>
 	public static Task<IReadOnlyList<IElement>> WaitForElementsAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector)
 		where TComponent : IComponent
-		=> WaitForElementsCoreAsync<TComponent>(renderedComponent, cssSelector, matchElementCount: null, timeout: null);
+		=> WaitForElementsCoreAsync<TComponent, IElement>(renderedComponent, cssSelector, matchElementCount: null, timeout: null);
+	/// <summary>
+	/// Wait until at least one element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static Task<IReadOnlyList<TElement>> WaitForElementsAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: null, timeout: null);
+
+	/// <summary>
+	/// Wait until exactly <paramref name="matchElementCount"/> element(s) of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the timeout is reached (default is one second).
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="matchElementCount">The exact number of elements to that the <paramref name="cssSelector"/> should match.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static Task<IReadOnlyList<TElement>> WaitForElementsAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, int matchElementCount)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: matchElementCount, timeout: null);
+
+	/// <summary>
+	/// Wait until at least one element of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="timeout">The maximum time to wait for elements to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static Task<IReadOnlyList<TElement>> WaitForElementsAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: null, timeout: timeout);
+
+	/// <summary>
+	/// Wait until exactly <paramref name="matchElementCount"/> element(s) of type <typeparamref name="TElement"/> matching the <paramref name="cssSelector"/> exists in the <paramref name="renderedComponent"/>,
+	/// or the <paramref name="timeout"/> is reached.
+	/// </summary>
+	/// <typeparam name="TComponent">The type of the component under test.</typeparam>
+	/// <typeparam name="TElement">The type of elements to wait for (e.g., IHtmlInputElement).</typeparam>
+	/// <param name="renderedComponent">The render fragment or component find the matching element in.</param>
+	/// <param name="cssSelector">The CSS selector to use to search for elements.</param>
+	/// <param name="matchElementCount">The exact number of elements to that the <paramref name="cssSelector"/> should match.</param>
+	/// <param name="timeout">The maximum time to wait for elements to appear.</param>
+	/// <exception cref="WaitForFailedException">Thrown if no elements is found matching the <paramref name="cssSelector"/> within the default timeout.</exception>
+	/// <returns>The <see cref="IReadOnlyList{TElement}"/>.</returns>
+	public static Task<IReadOnlyList<TElement>> WaitForElementsAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, int matchElementCount, TimeSpan timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
+		=> WaitForElementsCoreAsync<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount: matchElementCount, timeout: timeout);
 
 	private static IElement WaitForElementCore<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout)
 		where TComponent : IComponent
+		=> WaitForElementCore<TComponent, IElement>(renderedComponent, cssSelector, timeout);
+
+	private static TElement WaitForElementCore<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
 	{
-		using var waiter = new WaitForElementHelper<TComponent>(renderedComponent, cssSelector, timeout);
+		using var waiter = new WaitForElementHelper<TComponent, TElement>(renderedComponent, cssSelector, timeout);
 
 		try
 		{
@@ -177,10 +371,15 @@ public static partial class RenderedComponentWaitForHelperExtensions
 		}
 	}
 
-	private static async Task<IElement> WaitForElementCoreAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout)
+	private static Task<IElement> WaitForElementCoreAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout)
 		where TComponent : IComponent
+		=> WaitForElementCoreAsync<TComponent, IElement>(renderedComponent, cssSelector, timeout);
+
+	private static async Task<TElement> WaitForElementCoreAsync<TComponent, TElement>(this IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
 	{
-		using var waiter = new WaitForElementHelper<TComponent>(renderedComponent, cssSelector, timeout);
+		using var waiter = new WaitForElementHelper<TComponent, TElement>(renderedComponent, cssSelector, timeout);
 
 		return await waiter.WaitTask;
 	}
@@ -191,8 +390,17 @@ public static partial class RenderedComponentWaitForHelperExtensions
 		int? matchElementCount,
 		TimeSpan? timeout)
 		where TComponent : IComponent
+		=> WaitForElementsCore<TComponent, IElement>(renderedComponent, cssSelector, matchElementCount, timeout);
+
+	private static IReadOnlyList<TElement> WaitForElementsCore<TComponent, TElement>(
+		this IRenderedComponent<TComponent> renderedComponent,
+		string cssSelector,
+		int? matchElementCount,
+		TimeSpan? timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
 	{
-		using var waiter = new WaitForElementsHelper<TComponent>(renderedComponent, cssSelector, matchElementCount, timeout);
+		using var waiter = new WaitForElementsHelper<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount, timeout);
 
 		try
 		{
@@ -207,14 +415,23 @@ public static partial class RenderedComponentWaitForHelperExtensions
 		}
 	}
 
-	private static async Task<IReadOnlyList<IElement>> WaitForElementsCoreAsync<TComponent>(
+	private static Task<IReadOnlyList<IElement>> WaitForElementsCoreAsync<TComponent>(
 		this IRenderedComponent<TComponent> renderedComponent,
 		string cssSelector,
 		int? matchElementCount,
 		TimeSpan? timeout)
 		where TComponent : IComponent
+		=> WaitForElementsCoreAsync<TComponent, IElement>(renderedComponent, cssSelector, matchElementCount, timeout);
+
+	private static async Task<IReadOnlyList<TElement>> WaitForElementsCoreAsync<TComponent, TElement>(
+		this IRenderedComponent<TComponent> renderedComponent,
+		string cssSelector,
+		int? matchElementCount,
+		TimeSpan? timeout)
+		where TComponent : IComponent
+		where TElement : class, IElement
 	{
-		using var waiter = new WaitForElementsHelper<TComponent>(renderedComponent, cssSelector, matchElementCount, timeout);
+		using var waiter = new WaitForElementsHelper<TComponent, TElement>(renderedComponent, cssSelector, matchElementCount, timeout);
 
 		return await waiter.WaitTask;
 	}

--- a/src/bunit/Extensions/WaitForHelpers/WaitForElementHelper.cs
+++ b/src/bunit/Extensions/WaitForHelpers/WaitForElementHelper.cs
@@ -5,8 +5,21 @@ namespace Bunit.Extensions.WaitForHelpers;
 /// <summary>
 /// Represents an async wait helper, that will wait for a specified time for an element to become available in the DOM.
 /// </summary>
-internal class WaitForElementHelper<TComponent> : WaitForHelper<IElement, TComponent>
+internal class WaitForElementHelper<TComponent> : WaitForElementHelper<TComponent, IElement>
 	where TComponent : IComponent
+{
+	public WaitForElementHelper(IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout = null)
+		: base(renderedComponent, cssSelector, timeout)
+	{
+	}
+}
+
+/// <summary>
+/// Represents an async wait helper, that will wait for a specified time for an element of type <typeparamref name="TElement"/> to become available in the DOM.
+/// </summary>
+internal class WaitForElementHelper<TComponent, TElement> : WaitForHelper<TElement, TComponent>
+	where TComponent : IComponent
+	where TElement : class, IElement
 {
 	internal const string TimeoutBeforeFoundMessage = "The CSS selector and/or predicate did not result in a matching element before the timeout period passed.";
 
@@ -19,7 +32,7 @@ internal class WaitForElementHelper<TComponent> : WaitForHelper<IElement, TCompo
 	public WaitForElementHelper(IRenderedComponent<TComponent> renderedComponent, string cssSelector, TimeSpan? timeout = null)
 		: base(renderedComponent, () =>
 		{
-			var element = renderedComponent.Find(cssSelector);
+			var element = renderedComponent.Find<TComponent, TElement>(cssSelector);
 			return (true, element);
 		}, timeout)
 	{

--- a/src/bunit/Extensions/WaitForHelpers/WaitForElementsHelper.cs
+++ b/src/bunit/Extensions/WaitForHelpers/WaitForElementsHelper.cs
@@ -7,8 +7,21 @@ namespace Bunit.Extensions.WaitForHelpers;
 /// <summary>
 /// Represents an async wait helper, that will wait for a specified time for element(s) to become available in the DOM.
 /// </summary>
-internal class WaitForElementsHelper<TComponent> : WaitForHelper<IReadOnlyList<IElement>, TComponent>
+internal class WaitForElementsHelper<TComponent> : WaitForElementsHelper<TComponent, IElement>
 	where TComponent : IComponent
+{
+	public WaitForElementsHelper(IRenderedComponent<TComponent> renderedComponent, string cssSelector, int? matchElementCount, TimeSpan? timeout = null)
+		: base(renderedComponent, cssSelector, matchElementCount, timeout)
+	{
+	}
+}
+
+/// <summary>
+/// Represents an async wait helper, that will wait for a specified time for element(s) of type <typeparamref name="TElement"/> to become available in the DOM.
+/// </summary>
+internal class WaitForElementsHelper<TComponent, TElement> : WaitForHelper<IReadOnlyList<TElement>, TComponent>
+	where TComponent : IComponent
+	where TElement : class, IElement
 {
 	internal const string TimeoutBeforeFoundMessage = "The CSS selector did not result in any matching element(s) before the timeout period passed.";
 	internal static readonly CompositeFormat TimeoutBeforeFoundWithCountMessage = CompositeFormat.Parse("The CSS selector did not result in exactly {0} matching element(s) before the timeout period passed.");
@@ -25,7 +38,7 @@ internal class WaitForElementsHelper<TComponent> : WaitForHelper<IReadOnlyList<I
 	public WaitForElementsHelper(IRenderedComponent<TComponent> renderedComponent, string cssSelector, int? matchElementCount, TimeSpan? timeout = null)
 		: base(renderedComponent, () =>
 		{
-			var elements = renderedComponent.FindAll(cssSelector);
+			var elements = renderedComponent.FindAll<TComponent, TElement>(cssSelector);
 
 			var checkPassed = matchElementCount is null
 				? elements.Count > 0

--- a/tests/bunit.tests/Extensions/WaitForHelpers/RenderedComponentWaitForElementsHelperExtensionsTest.cs
+++ b/tests/bunit.tests/Extensions/WaitForHelpers/RenderedComponentWaitForElementsHelperExtensionsTest.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using AngleSharp.Html.Dom;
 
 namespace Bunit.Extensions.WaitForHelpers;
 
@@ -96,5 +97,56 @@ public class RenderedComponentWaitForElementsHelperExtensionsTest : BunitContext
 		var elms = cut.WaitForElements("main > p", matchElementCount: 0);
 
 		elms.ShouldBeEmpty();
+	}
+
+	[Fact(DisplayName = "WaitForElement<TElement> waits until element of specified type matching cssSelector appears")]
+	[Trait("Category", "sync")]
+	public void Test026()
+	{
+		var expectedMarkup = "<input type='text' id='myInput' />";
+		var cut = Render<DelayRenderFragment>(ps => ps.AddChildContent(expectedMarkup));
+
+		var elm = cut.WaitForElement<DelayRenderFragment, IHtmlInputElement>("#myInput");
+
+		elm.ShouldNotBeNull();
+		elm.Type.ShouldBe("text");
+	}
+
+	[Fact(DisplayName = "WaitForElement<TElement> throws exception when element type does not match")]
+	[Trait("Category", "sync")]
+	public void Test027()
+	{
+		var cut = Render<DelayRenderFragment>(ps => ps.AddChildContent("<div id='myDiv'></div>"));
+
+		var expected = Should.Throw<WaitForFailedException>(() =>
+			cut.WaitForElement<DelayRenderFragment, IHtmlInputElement>("#myDiv", WaitForTestTimeout));
+
+		expected.InnerException.ShouldBeOfType<ElementNotFoundException>();
+	}
+
+	[Fact(DisplayName = "WaitForElements<TElement> waits until elements of specified type matching cssSelector appear")]
+	[Trait("Category", "sync")]
+	public void Test028()
+	{
+		var expectedMarkup = "<input type='text' /><div></div><input type='checkbox' />";
+		var cut = Render<DelayRenderFragment>(ps => ps.AddChildContent(expectedMarkup));
+
+		var elms = cut.WaitForElements<DelayRenderFragment, IHtmlInputElement>("main input");
+
+		elms.Count.ShouldBe(2);
+		elms[0].ShouldBeAssignableTo<IHtmlInputElement>();
+		elms[1].ShouldBeAssignableTo<IHtmlInputElement>();
+	}
+
+	[Fact(DisplayName = "WaitForElements<TElement> with count waits until exactly N elements of specified type appear")]
+	[Trait("Category", "sync")]
+	public void Test029()
+	{
+		var expectedMarkup = "<input type='text' /><input type='checkbox' /><input type='password' />";
+		var cut = Render<DelayRenderFragment>(ps => ps.AddChildContent(expectedMarkup));
+
+		var elms = cut.WaitForElements<DelayRenderFragment, IHtmlInputElement>("main input", matchElementCount: 3);
+
+		elms.Count.ShouldBe(3);
 	}
 }

--- a/tests/bunit.tests/Rendering/RenderedComponentTest.cs
+++ b/tests/bunit.tests/Rendering/RenderedComponentTest.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using Bunit.Rendering;
 
 namespace Bunit;
@@ -255,7 +256,47 @@ public class RenderedComponentTest : BunitContext
 
 		cut.Instance.Invoked.ShouldBeTrue();
 	}
-	
+
+	[Fact(DisplayName = "Find<TElement> returns element of specified type when it matches")]
+	public void Test026()
+	{
+		var cut = Render<Wrapper>(x => x.AddChildContent("<input type='text' id='myInput' />"));
+
+		var result = cut.Find<Wrapper, IHtmlInputElement>("#myInput");
+
+		result.ShouldNotBeNull();
+		result.Type.ShouldBe("text");
+	}
+
+	[Fact(DisplayName = "Find<TElement> throws ElementNotFoundException when no element matches selector")]
+	public void Test027()
+	{
+		var cut = Render<Wrapper>(x => x.AddChildContent("<div></div>"));
+
+		Should.Throw<ElementNotFoundException>(() => cut.Find<Wrapper, IHtmlInputElement>("#nonexistent"));
+	}
+
+	[Fact(DisplayName = "FindAll<TElement> returns only elements of specified type")]
+	public void Test028()
+	{
+		var cut = Render<Wrapper>(x => x.AddChildContent("<input type='text' /><div></div><input type='checkbox' />"));
+
+		var results = cut.FindAll<Wrapper, IHtmlInputElement>("*");
+
+		results.Count.ShouldBe(2);
+		results.ShouldAllBe(e => e is IHtmlInputElement);
+	}
+
+	[Fact(DisplayName = "FindAll<TElement> returns empty list when no elements match the type")]
+	public void Test029()
+	{
+		var cut = Render<Wrapper>(x => x.AddChildContent("<div></div><span></span>"));
+
+		var results = cut.FindAll<Wrapper, IHtmlInputElement>("*");
+
+		results.ShouldBeEmpty();
+	}
+
 	private class BaseComponent : ComponentBase
 	{
 		protected override void BuildRenderTree(RenderTreeBuilder builder)


### PR DESCRIPTION
Add `Find<TComponent, TElement>` as a convenient way of having `TElement` returned.

So folks don't have to do:
```csharp
var element = cut.Find("a") as IHtmlAnchorElement;

element.ShouldNotBeNull();
element.AssertWhatever();
```

Of course - if they are sure they could use:
```csharp
var element = (IHtmAnchorElement)cut.Find("a");
```

And would get an exception. The new API would help here a bit better with a proper message inside the exception. That is also why I did not use `Nodes.QuerySelector<TElement>` internally, so that we can distinguish between:
 1. The css selector doesn't yield any element in the DOM
 2. There is an element, but the type is different