### PR TITLE
feat: Update version increment options to include "build"

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       versionIncrement:
-        description: 'The version increment. Allowed values are "major" and "minor".'
+        description: 'The version increment. Allowed values are "major", "minor" and "build".'
         required: true
         default: 'minor'
 
@@ -13,7 +13,7 @@ jobs:
   prepare-release:
     name: 🚚 Prepare new release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && contains(fromJson('["major","minor"]'), github.event.inputs.versionIncrement)
+    if: github.ref == 'refs/heads/main' && contains(fromJson('["major","minor","build"]'), github.event.inputs.versionIncrement)
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
nbgv allows build increments, and here and there I would have used it over a minor release (literally our latest release would have been that because it doesn't offer a new API).

Value taken from here: http://github.com/dotnet/Nerdbank.GitVersioning/blob/main/src/NerdBank.GitVersioning/VersionOptions.cs#L240